### PR TITLE
Move kernel selection to kickstart file

### DIFF
--- a/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
@@ -48,6 +48,9 @@ btrfs /    --subvol --name=root btr_pool\
   if [[ "${ROOT_FS,,}" = "btrfs" ]]; then
     sed -i -e 's!^part / .*$!'"${btrfs}"'!' "${WORKSPACE}/${KS_FILE}"
   fi
+
+  # Pass kernel selection
+  sed -i -e 's!^KERNEL=.*$!KERNEL='"${KERNEL}"'!' "${WORKSPACE}/${KS_FILE}"
 }
 
 #######################################

--- a/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
@@ -138,9 +138,9 @@ crontabs
 
 %end
 
-%post --interpreter /bin/sh
+%post --interpreter /bin/bash --log=/root/ks-post.log
 
-echo -n "Network fixes"
+echo "Network fixes"
 # initscripts don't like this file to be missing.
 cat > /etc/sysconfig/network << EOF
 NETWORKING=yes
@@ -171,7 +171,7 @@ cat > /etc/hosts << EOF
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
 EOF
-echo .
+
 # make sure firstboot doesn't start
 echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
 %end

--- a/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
@@ -174,4 +174,27 @@ EOF
 
 # make sure firstboot doesn't start
 echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
+
+# Install latest kernel, that way it will be available at first boot and
+# allow proper cleanup
+KERNEL=uek
+echo "Kernel update (${KERNEL^^})"
+
+echo  "Running kernel: $(uname -r)"
+echo "Kernel(s) installed:"
+rpm -qa | grep '^kernel' | sort
+
+kernel="kernel"
+yum_options="-d1"
+if [[ "${KERNEL,,}" = "modrhck" ]]; then
+  yum_options="${yum_options} --enablerepo ol7_MODRHCK"
+elif [[ "${KERNEL,,}" = "uek" ]]; then
+  yum_options="${yum_options} --enablerepo ol7_UEKR5"
+  kernel="kernel-uek"
+fi
+
+# Set default kernel
+sed -i -e 's/^DEFAULTKERNEL=.*/DEFAULTKERNEL='"${kernel}"'/' /etc/sysconfig/kernel
+
+yum install -y ${yum_options} ${kernel}
 %end

--- a/oracle-linux-image-tools/distr/ol7-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/provision.sh
@@ -31,6 +31,23 @@ distr::remove_rpms() {
 }
 
 #######################################
+# Print kickstart log
+# Globals:
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+distr::ks_log() {
+  if [[ -f "/root/ks-post.log" ]]; then
+    echo_message "Kickstart post log - Start"
+    cat /root/ks-post.log
+    rm /root/ks-post.log
+    echo_message "Kickstart post log - End"
+  fi
+}
+
+#######################################
 # Kernel configuration
 # Globals:
 #   DRACUT_CMD, KERNEL, UPDATE_TO_LATEST, YUM_VERBOSE
@@ -97,7 +114,7 @@ distr::kernel_config() {
 #   None
 # Returns:
 #   None
-#######################################distr::provision()
+#######################################
 distr::common_cfg() {
   local service tty
 
@@ -192,8 +209,9 @@ distr::common_cfg() {
 #   None
 # Returns:
 #   None
-#######################################distr::provision()
+#######################################
 distr::provision() {
+  distr::ks_log
   distr::kernel_config
   distr::common_cfg
 }


### PR DESCRIPTION
This change allows to use the latest selected kernel at first boot and simplifies cleanup during provisioning stage.

Also includes a commit to save and display the kickstart _post_ output.