### PR TITLE
Remove /usr/bin prefix on packer command line invocation

### DIFF
--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -430,7 +430,7 @@ run_packer() {
   echo_message "Invoke Packer"
   local errexit="$(shopt -po errexit)"
   set +e
-  /usr/bin/packer build -on-error=ask ${VM_NAME}.json
+  packer build -on-error=ask ${VM_NAME}.json
   packer_status=$?
   eval "${errexit}"
 


### PR DESCRIPTION
macOS homebrew installs packer in /usr/local/bin.