### PR TITLE
Miscelaneous updates to oracle-linux-image-tools

### DIFF
--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -210,6 +210,9 @@ load_env() {
   [[ "${SETUP_SWAP,,}" =~ ^(yes)|(no)$ ]] || error "SETUP_SWAP must be yes or no"
   readonly SETUP_SWAP
 
+  [[ "${X2APIC,,}" =~ ^(on)|(off)$ ]] || error "X2APIC must be on or off"
+  readonly X2APIC="${X2APIC,,}"
+
   # Source image scripts
   if [[ -r "${DISTR_DIR}/${DISTR}/${IMAGE_SCRIPTS}" ]]; then
     source "${DISTR_DIR}/${DISTR}/${IMAGE_SCRIPTS}"
@@ -332,6 +335,7 @@ stage_kickstart() {
 #   SSH_PASSWORD SSH_KEY_FILE
 #   VM_NAME
 #   WORKSPACE PACKER_FILES BIN_DIR PROVISION_SCRIPT
+#   X2APIC
 # Arguments:
 #   None
 # Returns:
@@ -376,6 +380,7 @@ packer_conf() {
 	      "shutdown_command": "$SHUTDOWN_CMD",
 	      "vboxmanage":
 	      [
+	        ["modifyvm", "{{.Name}}", "--x2apic", "${X2APIC}"],
 	        ["modifyvm", "{{.Name}}", "--memory", ${MEM_SIZE}],
 	        ["modifyvm", "{{.Name}}", "--cpus", ${CPU_NUM}]
 	      ]

--- a/oracle-linux-image-tools/cloud/none/image-scripts.sh
+++ b/oracle-linux-image-tools/cloud/none/image-scripts.sh
@@ -43,4 +43,5 @@ cloud::image_package() {
   vboxmanage convertfromraw System.img --format VMDK "${vmdk}" --variant Stream
   rm System.img
   tar cvf "${VM_NAME}.ova" "${VM_NAME}.ovf" "${vmdk}"
+  rm "${vmdk}"
 }

--- a/oracle-linux-image-tools/cloud/vagrant-virtualbox/provision.sh
+++ b/oracle-linux-image-tools/cloud/vagrant-virtualbox/provision.sh
@@ -44,7 +44,7 @@ cloud::install_agent()
 {
   echo_message "Install guest agent"
   local additions="/mnt/VBoxLinuxAdditions.run"
-  yum install -y ${YUM_VERBOSE} make gcc bzip2
+  yum install -y ${YUM_VERBOSE} make gcc bzip2 tar
 
   if [[ "${KERNEL,,}" = "uek" ]]; then
     yum install -y ${YUM_VERBOSE} kernel-uek-devel

--- a/oracle-linux-image-tools/distr/ol7-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol7-slim/env.properties
@@ -13,7 +13,7 @@ ROOT_FS="xfs"
 
 # Boot command
 # Variables MUST be escaped as they are evaluated at build time.
-BOOT_COMMAND='<up><tab> text ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} <enter>'
+BOOT_COMMAND='<up><tab>${CONSOLE} text ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} <enter>'
 
 # Kernel: uek, rhck or modrhck
 KERNEL="uek"

--- a/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
@@ -175,6 +175,14 @@ EOF
 # make sure firstboot doesn't start
 echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
 
+# Ensure we don't reboot with the serial console enabled
+sed -i \
+  -e 's/ console=ttyS0//' \
+  -e 's/^GRUB_TERMINAL.*/GRUB_TERMINAL_OUTPUT="console"'/ \
+  -e '/^GRUB_SERIAL_COMMAND/d' \
+  /etc/default/grub
+grub2-mkconfig -o /boot/grub2/grub.cfg
+
 # Install latest kernel, that way it will be available at first boot and
 # allow proper cleanup
 KERNEL=uek

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -62,6 +62,10 @@ CLOUD="none"
 # you can disable X2APIC in VirtualBox for the build: on/off (default: on)
 # X2APIC=
 
+# Capture serial console in serial-console.txt during Kickstart. (Yes, No,
+# default: no) -- Useful for debugging Kickstart issues.
+# SERIAL_CONSOLE=
+
 # OVM Image version (Default: 1.0)
 # IMAGE_VERSION=
 

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -37,14 +37,6 @@ CLOUD="none"
 # Lock root account after provisioning? (Default: yes)
 # LOCK_ROOT=
 
-# Kickstart file needs to be provided via a http. We spawn a basic web server
-# during the build.
-# This is the default host IP as seen on the VirtualBox NAT interface.
-# HOST_IP="10.0.2.2"
-# The server will listen on this port
-# HOST_PORT=8000
-
-
 #
 # Override examples
 #

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -58,6 +58,10 @@ CLOUD="none"
 # Allocated disk size for the image, default is distribution / cloud specific
 # DISK_SIZE_GB=
 
+# If you experience issues when building in a nested virtualization environment,
+# you can disable X2APIC in VirtualBox for the build: on/off (default: on)
+# X2APIC=
+
 # OVM Image version (Default: 1.0)
 # IMAGE_VERSION=
 

--- a/oracle-linux-image-tools/env.properties.defaults
+++ b/oracle-linux-image-tools/env.properties.defaults
@@ -26,3 +26,6 @@ SSH_KEY_FILE=
 
 # Lock root account after provisioning?
 LOCK_ROOT="yes"
+
+# Use X2APIC in VirtualBox for the build? (on, off)
+X2APIC="on"

--- a/oracle-linux-image-tools/env.properties.defaults
+++ b/oracle-linux-image-tools/env.properties.defaults
@@ -29,3 +29,6 @@ LOCK_ROOT="yes"
 
 # Use X2APIC in VirtualBox for the build? (on, off)
 X2APIC="on"
+
+# Capture serial console in serial-console.txt during Kickstart? (yes, no)
+SERIAL_CONSOLE="no"

--- a/oracle-linux-image-tools/env.properties.defaults
+++ b/oracle-linux-image-tools/env.properties.defaults
@@ -9,13 +9,6 @@ CLOUD="none"
 # Build number
 BUILD_NUMBER=0
 
-# Kickstart file needs to be provided via a http. We spawn a basic web server
-# during the build.
-# This is the default host IP as seen on the VirtualBox NAT interface.
-HOST_IP="10.0.2.2"
-# The server will listen on this port
-HOST_PORT=8000
-
 # Number of CPUs for the build VM
 CPU_NUM=4
 # Memory allocated to the build VM


### PR DESCRIPTION
Some updates/improvements:
- use of packer's embedded web server for kickstart
- capture output of the kickstart stage (for debugging purpose)
- add parameter to disable `x2apic` in VirtuaBox during build (when running on older KVM guest)

No change in for the generated images.