### PR TITLE
OL Image tools: several enhancements

### DIFF
--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -195,6 +195,15 @@ load_env() {
   [[ "${LOCK_ROOT,,}" =~ ^(yes)|(no)$ ]] || error "LOCK_ROOT must be yes or no"
   readonly LOCK_ROOT
 
+  # Attempt to derive DISTR_NAME from the iso image name, otherwise fall back
+  # to the configured name
+  local distr_name
+  # shellcheck disable=SC2001
+  distr_name=$(sed -e 's/^.*OracleLinux-R\([[:digit:]]\)-U\([[:digit:]]\+\)\(-Server\)\?-\([^-]\+\)\(-dvd\)\?\(-[[:digit:]]\+\)\?\.iso$/OL\1U\2_\4/' <<< "${ISO_URL}")
+  if [[ $distr_name =~ ^OL[678]U ]]; then
+    DISTR_NAME="${distr_name}"
+  fi
+
   [[ -z "${DISTR_NAME}" && -z "${BUILD_NUMBER}" ]] &&
     error "missing distribution name / build number"
   if [[ -z "${VM_NAME}" ]]; then

--- a/oracle-linux-image-tools/cloud/vagrant-libvirt/image-scripts.sh
+++ b/oracle-linux-image-tools/cloud/vagrant-libvirt/image-scripts.sh
@@ -67,7 +67,14 @@ cloud::image_package() {
   config.vm.provider :libvirt do |libvirt|
     libvirt.memory = ${memory}
     libvirt.cpus = ${cpus}
+    libvirt.features = ['apic', 'acpi']
+    libvirt.video_vram = 16384
   end
+
+  config.vm.synced_folder ".", "/vagrant",
+    type: "nfs",
+    nfs_version: 3,
+    nfs_udp: false
 EOF
   ${VAGRANT_LIBVIRT_BOX_SCRIPT} "${VM_NAME}.qcow" "${VM_NAME}.box" Vagrantfile
   rm "${VM_NAME}.qcow" Vagrantfile

--- a/oracle-linux-image-tools/distr/ol7-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/provision.sh
@@ -68,9 +68,17 @@ distr::kernel_config() {
   # dracut configuration files so that they get installed into the initrd
   # during fresh kernel installs.
   # This makes it is easy to move VM images between these virtual environments
+
+  # Available virtio modules depends on kernel build...
+  local virtio modules
+  modules=$(find "/lib/modules/$(uname -r)" -name "virtio*.ko*" -printf '%f\n')
+  while read -r module; do
+    virtio="${virtio} ${module%.ko*}"
+  done <<<"${modules}"
+
   cat > /etc/dracut.conf.d/01-dracut-vm.conf <<-EOF
 	add_drivers+=" xen_netfront xen_blkfront "
-	add_drivers+=" virtio_blk virtio_net virtio virtio_pci virtio_balloon "
+	add_drivers+=" ${virtio} "
 	add_drivers+=" hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hyperv_fb "
 	add_drivers+=" ahci libahci "
 	EOF

--- a/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
@@ -92,6 +92,9 @@ part /        --fstype="xfs"  --ondisk=sda --size=4096 --label=root  --grow
 -prefixdevname
 -sg3_utils
 -sg3_utils-libs
+
+# hwdata blacklists several modules, a.o. the fb (frame buffer) ones
+hwdata
 %end
 
 %post --interpreter /bin/bash --log=/root/ks-post.log

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -69,11 +69,14 @@ distr::kernel_config() {
   # dracut configuration files so that they get installed into the initrd
   # during fresh kernel installs.
   # This makes it is easy to move VM images between these virtual environments
-  if [[ "${KERNEL,,}" = "uek" ]]; then
-    local virtio="virtio_blk virtio_net virtio_pci virtio_scsi virtio_balloon"
-  else
-    local virtio="virtio_blk virtio_net virtio_balloon"
-  fi
+
+  # Available virtio modules depends on kernel build...
+  local virtio modules
+  modules=$(find "/lib/modules/$(uname -r)" -name "virtio*.ko*" -printf '%f\n')
+  while read -r module; do
+    virtio="${virtio} ${module%.ko*}"
+  done <<<"${modules}"
+
   cat > /etc/dracut.conf.d/01-dracut-vm.conf <<-EOF
 	add_drivers+=" xen_netfront xen_blkfront "
 	add_drivers+=" ${virtio} "


### PR DESCRIPTION
This PR regroups several enhancements:

- Default value for the image name is now based on the ISO image name when possible
- OL8: add `hwdata` package which blacklists several modules (improves performance)
- Better defaults for the libvirt vagrant boxes
- Dynamic selection of `virtio` kernel modules to include in initramfs bundle.