### PR TITLE
Image tools: Default SELinux to Enforcing

### DIFF
--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -222,6 +222,9 @@ load_env() {
   [[ "${SETUP_SWAP,,}" =~ ^(yes)|(no)$ ]] || error "SETUP_SWAP must be yes or no"
   readonly SETUP_SWAP
 
+  [[ "${SELINUX,,}" =~ ^(enforcing)|(permissive)|(disabled)$ ]] || error "SELINUX must be enforcing, permissive or disabled"
+  readonly SELINUX
+
   [[ "${X2APIC,,}" =~ ^(on)|(off)$ ]] || error "X2APIC must be on or off"
   readonly X2APIC="${X2APIC,,}"
 

--- a/oracle-linux-image-tools/cloud/vagrant-virtualbox/files/vagrant-common.sh
+++ b/oracle-linux-image-tools/cloud/vagrant-virtualbox/files/vagrant-common.sh
@@ -91,9 +91,6 @@ EOF
   current_kernel=$(uname -r)
   ${DRACUT_CMD} -f "/boot/initramfs-${current_kernel}.img" "${current_kernel}"
 
-  # Set SELinux to enforcing
-  sed -i -e 's/^SELINUX\s*=.*/SELINUX=enforcing/' /etc/selinux/config
-
   # Disabling firewalld on vagrant boxes
   if [[ "${ORACLE_RELEASE}" = "6" ]]; then
     service iptables stop

--- a/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
@@ -33,7 +33,7 @@ rootpw --lock
 
 # System services
 services --disabled="firewalld,kdump,rhsmcertd" --enabled="ip6tables,iptables,network,sshd,rsyslog,chronyd"
-selinux --permissive
+selinux --enforcing
 firewall --service=ssh
 
 # System bootloader configuration

--- a/oracle-linux-image-tools/distr/ol7-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/provision.sh
@@ -173,8 +173,12 @@ distr::common_cfg() {
   echo_message "Set rp_filter to loose mode"
   echo "net.ipv4.conf.default.rp_filter = 2" >> /etc/sysctl.conf
 
-  echo_message "Set SELinux to Permissive"
-  sed -i -e 's/^SELINUX[  ]*=.*/SELINUX=permissive/' /etc/selinux/config
+  echo_message "Set SELinux to ${SELINUX^^}"
+  sed -i -e "s/^SELINUX[  ]*=.*/SELINUX=${SELINUX,,}/" /etc/selinux/config
+  if [[ ${SELINUX,,} != "enforcing" ]]; then
+    # Relax SELinux for the provisioning as well
+    setenforce Permissive
+  fi
 
   echo_message "Clear network persistent data"
   rm -f /etc/udev/rules.d/70-persistent-net.rules

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -160,8 +160,12 @@ distr::common_cfg() {
   echo_message "Set rp_filter to loose mode"
   echo "net.ipv4.conf.default.rp_filter = 2" >> /etc/sysctl.conf
 
-  echo_message "Set SELinux to Permissive"
-  sed -i -e 's/^SELINUX[  ]*=.*/SELINUX=permissive/' /etc/selinux/config
+  echo_message "Set SELinux to ${SELINUX^^}"
+  sed -i -e "s/^SELINUX[  ]*=.*/SELINUX=${SELINUX,,}/" /etc/selinux/config
+  if [[ ${SELINUX,,} != "enforcing" ]]; then
+    # Relax SELinux for the provisioning as well
+    setenforce Permissive
+  fi
 
   echo_message "Clear network persistent data"
   rm -f /etc/udev/rules.d/70-persistent-net.rules

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -44,6 +44,9 @@ CLOUD="none"
 # Setup swap? (Yes/No, default is distribution / cloud specific)
 # SETUP_SWAP=
 
+# SELinux state (enforcing, permissive, disabled)
+# SELINUX=
+
 # Root filesystem: btrfs, xfs or lvm (Default: xfs)
 # ROOT_FS=
 

--- a/oracle-linux-image-tools/env.properties.defaults
+++ b/oracle-linux-image-tools/env.properties.defaults
@@ -17,6 +17,9 @@ MEM_SIZE=8192
 # Setup swap?
 SETUP_SWAP="yes"
 
+# SELinux state (enforcing, permissive, disabled)
+SELINUX="enforcing"
+
 # Allocated disk size for the image.
 DISK_SIZE_GB=15
 


### PR DESCRIPTION
Images are now build with SELinux set to Enforcing by default

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>
