### PR TITLE
Oracle Linux image tools: OLVM Templates

### DIFF
--- a/oracle-linux-image-tools/cloud/olvm/env.properties
+++ b/oracle-linux-image-tools/cloud/olvm/env.properties
@@ -6,3 +6,6 @@
 CLOUD_INIT="No"
 # Cloud-init user (Empty variable means keep package default -- cloud-user)
 CLOUD_USER=
+
+# Generates a template instead of an image? (Yes/No)
+OLVM_TEMPLATE="No"

--- a/oracle-linux-image-tools/cloud/olvm/mk-envelope.py
+++ b/oracle-linux-image-tools/cloud/olvm/mk-envelope.py
@@ -201,7 +201,7 @@ def generate_ovf(args):
         'ovf:disk-interface': 'VirtIO',
         'ovf:boot': 'true',
         'ovf:disk-type': 'System',
-        'ovf:disk-alias': 'Disk ' + args.build,
+        'ovf:disk-alias': 'Disk_' + args.build,
     })
 
     # Envelope / Virtual System

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -88,6 +88,10 @@ CLOUD="none"
 # cloud-init user (Default is "opc" for OCI and "cloud-user" for OLVM)
 # CLOUD_USER=
 
+# OLVM:
+# Generates a template instead of an image? (Yes, No, default: No)
+# OLVM_TEMPLATE=
+
 # Vagrant virtualbox
 # Memory and CPU to allocate to the box by default at runtime (default: same
 # as build VM values)


### PR DESCRIPTION
Generate templates for Oracle Linux Virtualization Manager.

Add a parameter to package images as OLVM Template instead of VM images.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>