### PR TITLE
Image tools: Save package and repo information

### DIFF
--- a/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
@@ -84,6 +84,7 @@ distr::image_cleanup() {
 
   cp "${root_fs}"/home/rpm.list "${WORKSPACE}/${VM_NAME}/${VM_NAME}.pkglst"
   cp "${root_fs}"/home/rpm.csv "${WORKSPACE}/${VM_NAME}/pkglst.csv"
+  cp "${root_fs}"/home/repolist.txt "${WORKSPACE}/${VM_NAME}/repolist.txt"
   cp "${root_fs}"/home/kernel.txt "${WORKSPACE}/${VM_NAME}/${VM_NAME}.kernel"
 
   sudo chroot "${root_fs}" /bin/bash <<-EOF
@@ -95,6 +96,6 @@ distr::image_cleanup() {
 	rm -rf /var/spool/root /var/spool/mail/root
 	rm -rf /var/lib/NetworkManager
 	rm -rf /var/tmp/*
-	rm -f /home/rpm.list /home/rpm.csv /home/kernel.txt
+	rm -f /home/rpm.list /home/rpm.csv /home/repolist.txt /home/kernel.txt
 	EOF
 }

--- a/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
@@ -83,6 +83,7 @@ distr::image_cleanup() {
   [[ -z ${boot_fs} ]] && error "Undefined boot filesystem"
 
   cp "${root_fs}"/home/rpm.list "${WORKSPACE}/${VM_NAME}/${VM_NAME}.pkglst"
+  cp "${root_fs}"/home/rpm.csv "${WORKSPACE}/${VM_NAME}/pkglst.csv"
   cp "${root_fs}"/home/kernel.txt "${WORKSPACE}/${VM_NAME}/${VM_NAME}.kernel"
 
   sudo chroot "${root_fs}" /bin/bash <<-EOF
@@ -94,6 +95,6 @@ distr::image_cleanup() {
 	rm -rf /var/spool/root /var/spool/mail/root
 	rm -rf /var/lib/NetworkManager
 	rm -rf /var/tmp/*
-	rm -f /home/rpm.list /home/kernel.txt
+	rm -f /home/rpm.list /home/rpm.csv /home/kernel.txt
 	EOF
 }

--- a/oracle-linux-image-tools/distr/ol7-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/provision.sh
@@ -268,6 +268,7 @@ distr::cleanup() {
   done
 
   echo_message "Yum cleanup"
+  yum -q repolist > /home/repolist.txt
   : > /etc/yum/vars/ociregion
   rm -rf /var/cache/yum/*
   rm -rf /var/lib/yum/*

--- a/oracle-linux-image-tools/distr/ol7-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/provision.sh
@@ -350,6 +350,7 @@ distr::cleanup() {
 
   echo_message "Save list of installed packages"
   rpm -qa --qf "%{name}.%{arch}\n"  | sort -u > /home/rpm.list
+  rpm -qa --qf '"%{NAME}","%{EPOCHNUM}","%{VERSION}","%{RELEASE}","%{ARCH}"\n' | sort > /home/rpm.csv
   uname -r > /home/kernel.txt
 
   echo_message "Relabel SELinux"

--- a/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
@@ -77,6 +77,7 @@ distr::image_cleanup() {
 
   cp "${root_fs}"/home/rpm.list "${WORKSPACE}/${VM_NAME}/${VM_NAME}.pkglst"
   cp "${root_fs}"/home/rpm.csv "${WORKSPACE}/${VM_NAME}/pkglst.csv"
+  cp "${root_fs}"/home/repolist.txt "${WORKSPACE}/${VM_NAME}/repolist.txt"
   cp "${root_fs}"/home/kernel.txt "${WORKSPACE}/${VM_NAME}/${VM_NAME}.kernel"
 
   sudo chroot "${root_fs}" /bin/bash <<-EOF
@@ -88,6 +89,6 @@ distr::image_cleanup() {
 	rm -rf /var/spool/root /var/spool/mail/root
 	rm -rf /var/lib/NetworkManager
 	rm -rf /var/tmp/*
-	rm -f /home/rpm.list /home/rpm.csv /home/kernel.txt
+	rm -f /home/rpm.list /home/rpm.csv /home/repolist.txt /home/kernel.txt
 	EOF
 }

--- a/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
@@ -76,6 +76,7 @@ distr::image_cleanup() {
   [[ -z ${boot_fs} ]] && error "Undefined boot filesystem"
 
   cp "${root_fs}"/home/rpm.list "${WORKSPACE}/${VM_NAME}/${VM_NAME}.pkglst"
+  cp "${root_fs}"/home/rpm.csv "${WORKSPACE}/${VM_NAME}/pkglst.csv"
   cp "${root_fs}"/home/kernel.txt "${WORKSPACE}/${VM_NAME}/${VM_NAME}.kernel"
 
   sudo chroot "${root_fs}" /bin/bash <<-EOF
@@ -87,6 +88,6 @@ distr::image_cleanup() {
 	rm -rf /var/spool/root /var/spool/mail/root
 	rm -rf /var/lib/NetworkManager
 	rm -rf /var/tmp/*
-	rm -f /home/rpm.list /home/kernel.txt
+	rm -f /home/rpm.list /home/rpm.csv /home/kernel.txt
 	EOF
 }

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -331,6 +331,7 @@ distr::cleanup() {
 
   echo_message "Save list of installed packages"
   rpm -qa --qf "%{name}.%{arch}\n"  | sort -u > /home/rpm.list
+  rpm -qa --qf '"%{NAME}","%{EPOCHNUM}","%{VERSION}","%{RELEASE}","%{ARCH}"\n' | sort > /home/rpm.csv
   uname -r > /home/kernel.txt
 
   echo_message "Relabel SELinux"

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -247,6 +247,7 @@ distr::cleanup() {
   done
 
   echo_message "Dnf cleanup"
+  dnf -q repolist > /home/repolist.txt
   : > /etc/dnf/vars/ociregion
   rm -rf /var/cache/dnf/*
   rm -rf /var/lib/dnf/*


### PR DESCRIPTION
Two additional files are saved during the build:
- `pkglst.csv` as CSV formatted file with the list of packages installed and their version
- `repolist.txt` the list of the enabled repositories

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>