### PR TITLE
Add support for provisioning from a boot ISO image

### DIFF
--- a/oracle-linux-image-tools/README.md
+++ b/oracle-linux-image-tools/README.md
@@ -1,13 +1,14 @@
-Oracle Linux image tools
-========================
+# Oracle Linux image tools
 
-# Description
+## Description
+
 This repository provides tools to build Oracle Linux images for cloud deployment.
 
 The images built by these tools are based on distribution flavours and target packages.
 Image building is accomplished using Packer to build images from the Oracle Linux ISO using Oracle VM VirtualBox.
 
 The tool currently supports:
+
 - Distributions:
   - Oracle Linux 7 update 8 -- Slim  
     A minimal set of packages is installed
@@ -35,11 +36,12 @@ The tool currently supports:
     Target packages: none  
     Image format: OVA
 
-# Build instructions
+## Build instructions
+
 1. Install packer and VirtualBox:  
   `yum --enablerepo=ol7_developer install packer VirtualBox-6.0`
 1. Cloud specific requirements:
-   - For `OCI` or `OLVM` images, install the ` qemu-img` package:  
+   - For `OCI` or `OLVM` images, install the `qemu-img` package:  
     `yum install qemu-img`
    - For `Vagrant` box (VirtualBox provider), install [HashiCorp Vagrant](https://vagrantup.com/)
    - For `Vagrant` box (libvirt provider), download the [`create_box.sh`](https://github.com/vagrant-libvirt/vagrant-libvirt/blob/master/tools/create_box.sh) third party script from the [`vagrant-libvirt`](https://github.com/vagrant-libvirt/vagrant-libvirt) project or install [HashiCorp Vagrant](https://vagrantup.com/) and the [`vagrant-libvirt`](https://github.com/vagrant-libvirt/vagrant-libvirt) plugin
@@ -58,8 +60,10 @@ The tool currently supports:
 1. Run the buider:  
   `./bin/build-image.sh --env ENV_PROPERTY_FILE`
 
-# Advanced configuration
+## Advanced configuration
+
 For a given Oracle Linux distribution and target Cloud, the following properties are taken in consideration:
+
 - Global `env.properties.default` file
 - Distribution `env.properties` file
 - Cloud `env.properties` file
@@ -70,10 +74,13 @@ Files are processed in that order.
 As user you should only make changes in your local `env.properties` where you can override any definition from the previous property files.  
 Relevant parameters are documented in the distributed [`env.properties`](env.properties) file.
 
-# Cloud specific notes
-## OCI
+## Cloud specific notes
+
+### OCI
+
 The Oracle Cloud Infrastructure `oci` cloud target generates an `QCOW2` file which can be uploaded in an _Object Storage_ bucket and imported as _Custom Image_.
 This can be done from the Console, or using the [Command Line Interface (CLI)](https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/cliconcepts.htm). E.g.:
+
 ```shell
 # Upload in the Object Storage Bucket
 oci os object put -bn my_bucket \
@@ -96,14 +103,18 @@ oci work-requests work-request get \
 # my_image_ocid and my_work_request_ocid OCIDs are returned  by the import command
 ```
 
-## OLVM
+### OLVM
+
 The `olvm` cloud target generates an OVA file. The process to import OVA files in the Oracle Linux Virtualization Manager is described in this [blog post](https://blogs.oracle.com/scoter/import-configure-oracle-linux-7-template-for-oracle-linux-kvm).
 
 For cloud-init support, you will need to specify `CLOUD_INIT="Yes"` in your `env.properties` file.
 
-# Builder architecture
-## Directory structure
+## Builder architecture
+
+### Directory structure
+
 The `build-image` script relies on the following directory structure:
+
 - distr: directory for all Oracle Linux distribution
   - _distribution name_
     - env.properties: distribution parameters
@@ -121,14 +132,16 @@ The `build-image` script relies on the following directory structure:
 
 Most of the files are optional, only define what is needed.
 
-## Build process
+### Build process
+
 The builder will process the directories in the following order:
+
 1. Read properties files as described in [advanced configuration](#advanced-configuration).  
   The properties are available in all scripts, on the host and in the VM during provisioning.  
   Properties can be validated at distribution / cloud level:
-  - distr::validate
-  - cloud::validate
-  - cloud_distr::validate
+    - distr::validate
+    - cloud::validate
+    - cloud_distr::validate
 1. Select a kickstart file from _distr_ and customise it. The following hooks are called if defined:
     - distr::kickstart
     - cloud_distr::kickstart
@@ -150,8 +163,10 @@ The builder will process the directories in the following order:
     - cloud_distr::image_package
     - cloud::image_package
 
-# Feedback
+## Feedback
+
 Please provide feedback of any kind via GitHub issues on this repository.
 
-# Contributing
+## Contributing
+
 See [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/oracle-linux-image-tools/README.md
+++ b/oracle-linux-image-tools/README.md
@@ -86,7 +86,7 @@ For a given Oracle Linux distribution and target Cloud, the following properties
 - Local `env.properties` file (passed as parameter to the builder)
 
 Files are processed in that order.  
-As user you should only make changes in your local `env.properties` where you can override any definition from the previous property files.  
+Changes should be made to a local env.properties file which can override any definition made in an upstream property file.  
 Relevant parameters are documented in the distributed [`env.properties`](env.properties) file.
 
 ## Cloud specific notes

--- a/oracle-linux-image-tools/README.md
+++ b/oracle-linux-image-tools/README.md
@@ -70,8 +70,8 @@ In that case, you will have to provide an URL to an installation tree and option
 Example for an Oracle Linux 8 Update 2 using the UEK boot ISO:
 
 ```Shell
-ISO_URL="http://yum.oracle.com/ISOS/OracleLinux/OL8/u2/x86_64/x86_64-boot-uek.iso"
-REPO_URL="http://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64"
+ISO_URL="https://yum.oracle.com/ISOS/OracleLinux/OL8/u2/x86_64/x86_64-boot-uek.iso"
+REPO_URL="https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64"
 REPO[AppStream]="https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64"
 ```
 

--- a/oracle-linux-image-tools/README.md
+++ b/oracle-linux-image-tools/README.md
@@ -62,6 +62,21 @@ The tool currently supports:
 
 ## Advanced configuration
 
+### Using _boot_ ISO images
+
+Instead of providing an Oracle Linux distribution ISO you can use a _boot_ ISO image.
+In that case, you will have to provide an URL to an installation tree and optionally additional yum repositories required by the installation.
+
+Example for an Oracle Linux 8 Update 2 using the UEK boot ISO:
+
+```Shell
+ISO_URL="http://yum.oracle.com/ISOS/OracleLinux/OL8/u2/x86_64/x86_64-boot-uek.iso"
+REPO_URL="http://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64"
+REPO[AppStream]="https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64"
+```
+
+### Configuration files
+
 For a given Oracle Linux distribution and target Cloud, the following properties are taken in consideration:
 
 - Global `env.properties.default` file

--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -562,7 +562,7 @@ image_cleanup() {
   mkdir "${mnt}"
   sudo "${MOUNT_IMAGE}" System.img "${mnt}"
   boot_fs="${mnt}/1"
-  if df -T "${mnt}/2" | grep -q btrfs; then
+  if [[ $(stat -f -c "%T" "${mnt}/2") = "btrfs" ]]; then
     root_fs="${mnt}/2/root"
   else
     root_fs="${mnt}/2"

--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -334,6 +334,20 @@ stage_kickstart() {
     sed -i -e '/^part swap /d' "${WORKSPACE}/${KS_FILE}"
   fi
 
+  if [[ -n "${REPO_URL}" ]]; then
+    sed -i -e \
+      '/^# URL to an installation tree/a url --url "'"${REPO_URL}"'"' \
+      "${WORKSPACE}/${KS_FILE}"
+  fi
+
+  local repo
+  # shellcheck disable=SC2153
+  for repo in "${!REPO[@]}"; do
+    sed -i -e \
+      '/^# Additional yum repositories/a repo --name "'"${repo}"'" --baseurl "'"${REPO[${repo}]}"'"' \
+      "${WORKSPACE}/${KS_FILE}"
+  done
+
   # Kickstart fixups at distr / cloud_distr level
   if [[ "$(type -t distr::kickstart)" = 'function' ]]; then
     distr::kickstart "${WORKSPACE}/${KS_FILE}"

--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -340,11 +340,10 @@ stage_kickstart() {
       "${WORKSPACE}/${KS_FILE}"
   fi
 
-  local repo
-  # shellcheck disable=SC2153
-  for repo in "${!REPO[@]}"; do
+  local ks_repo
+  for ks_repo in "${!REPO[@]}"; do
     sed -i -e \
-      '/^# Additional yum repositories/a repo --name "'"${repo}"'" --baseurl "'"${REPO[${repo}]}"'"' \
+      '/^# Additional yum repositories/a repo --name "'"${ks_repo}"'" --baseurl "'"${REPO[${ks_repo}]}"'"' \
       "${WORKSPACE}/${KS_FILE}"
   done
 

--- a/oracle-linux-image-tools/distr/ol7-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol7-slim/env.properties
@@ -26,3 +26,6 @@ UEK_RELEASE=6
 
 # Update: yes, security, no
 UPDATE_TO_LATEST="yes"
+
+# Directory used to save build information
+readonly BUILD_INFO="/.build-info"

--- a/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
@@ -67,7 +67,7 @@ logvol /      --fstype=\"xfs\"  --vgname=vg_main --size=4096 --name=lv_root --gr
 #######################################
 # Cleanup actions run directly on the image
 # Globals:
-#   WORKSPACE VM_NAME
+#   WORKSPACE VM_NAME BUILD_INFO
 # Arguments:
 #   root filesystem directory
 #   boot filesystem directory
@@ -82,10 +82,9 @@ distr::image_cleanup() {
   [[ -z ${root_fs} ]] && error "Undefined root filesystem"
   [[ -z ${boot_fs} ]] && error "Undefined boot filesystem"
 
-  cp "${root_fs}"/home/rpm.list "${WORKSPACE}/${VM_NAME}/${VM_NAME}.pkglst"
-  cp "${root_fs}"/home/rpm.csv "${WORKSPACE}/${VM_NAME}/pkglst.csv"
-  cp "${root_fs}"/home/repolist.txt "${WORKSPACE}/${VM_NAME}/repolist.txt"
-  cp "${root_fs}"/home/kernel.txt "${WORKSPACE}/${VM_NAME}/${VM_NAME}.kernel"
+  if [[ -n ${BUILD_INFO} && -d "${root_fs}${BUILD_INFO}" ]]; then
+    find "${root_fs}${BUILD_INFO}" -type f -exec cp {} "${WORKSPACE}/${VM_NAME}/" \;
+  fi
 
   sudo chroot "${root_fs}" /bin/bash <<-EOF
   : > /var/log/wtmp
@@ -96,6 +95,6 @@ distr::image_cleanup() {
 	rm -rf /var/spool/root /var/spool/mail/root
 	rm -rf /var/lib/NetworkManager
 	rm -rf /var/tmp/*
-	rm -f /home/rpm.list /home/rpm.csv /home/repolist.txt /home/kernel.txt
+  [[ -n "${BUILD_INFO}" ]] && rm -rf "${BUILD_INFO}"
 	EOF
 }

--- a/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
@@ -40,10 +40,12 @@ distr::validate() {
 #######################################
 distr::kickstart() {
   local ks_file="$1"
+
   local btrfs="\
 part btrfs.01 --fstype=\"btrfs\"  --ondisk=sda --size=4096 --grow\n\
-btrfs none --label=btr_pool --data=single btrfs.01\n\
-btrfs /    --subvol --name=root btr_pool\
+btrfs none  --label=btrfs_vol --data=single btrfs.01\n\
+btrfs /     --subvol --name=root LABEL=btrfs_vol\n\
+btrfs /home --subvol --name=home LABEL=btrfs_vol\
 "
   local lvm="\
 part pv.01 --ondisk=sda --size=4096 --grow\n\

--- a/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
@@ -28,6 +28,10 @@ timezone UTC --isUtc
 # Network information
 network  --bootproto=dhcp --device=eth0 --onboot=yes --ipv6=auto --hostname=localhost.localdomain
 
+# URL to an installation tree on a remote server
+
+# Additional yum repositories that may be used as sources for package installation.
+
 # Root password -- will be overridden by the builder
 rootpw --lock
 

--- a/oracle-linux-image-tools/distr/ol7-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/provision.sh
@@ -118,7 +118,7 @@ distr::kernel_config() {
 #######################################
 # Common configuration
 # Globals:
-#   UPDATE_TO_LATEST, YUM_VERBOSE
+#   UPDATE_TO_LATEST, YUM_VERBOSE, BUILD_INFO
 # Arguments:
 #   None
 # Returns:
@@ -126,6 +126,9 @@ distr::kernel_config() {
 #######################################
 distr::common_cfg() {
   local service tty
+
+  # Directory to save build information
+  mkdir -p "${BUILD_INFO}"
 
   # Disable ol7_ociyum_config (Orabug 31106231)
   yum-config-manager --disable ol7_ociyum_config >/dev/null 2>&1
@@ -234,6 +237,7 @@ distr::provision() {
 #######################################
 # Cleanup
 # Globals:
+#   BUILD_INFO
 # Arguments:
 #   None
 # Returns:
@@ -268,7 +272,7 @@ distr::cleanup() {
   done
 
   echo_message "Yum cleanup"
-  yum -q repolist > /home/repolist.txt
+  yum -q repolist > "${BUILD_INFO}/repolist.txt"
   : > /etc/yum/vars/ociregion
   rm -rf /var/cache/yum/*
   rm -rf /var/lib/yum/*
@@ -350,9 +354,9 @@ distr::cleanup() {
   rm -f /var/log/ovm-template-config.log
 
   echo_message "Save list of installed packages"
-  rpm -qa --qf "%{name}.%{arch}\n"  | sort -u > /home/rpm.list
-  rpm -qa --qf '"%{NAME}","%{EPOCHNUM}","%{VERSION}","%{RELEASE}","%{ARCH}"\n' | sort > /home/rpm.csv
-  uname -r > /home/kernel.txt
+  rpm -qa --qf "%{name}.%{arch}\n"  | sort -u > "${BUILD_INFO}/pkglist.txt"
+  rpm -qa --qf '"%{NAME}","%{EPOCHNUM}","%{VERSION}","%{RELEASE}","%{ARCH}"\n' | sort > "${BUILD_INFO}/pkglist.csv"
+  uname -r > "${BUILD_INFO}/kernel.txt"
 
   echo_message "Relabel SELinux"
   genhomedircon

--- a/oracle-linux-image-tools/distr/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-slim/env.properties
@@ -11,7 +11,7 @@ readonly ORACLE_RELEASE=8
 # Setup swap?
 SETUP_SWAP="yes"
 
-# Root filesystem: xfs or lvm
+# Root filesystem: xfs, lvm or btrfs
 ROOT_FS="xfs"
 
 # Boot command

--- a/oracle-linux-image-tools/distr/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-slim/env.properties
@@ -23,3 +23,6 @@ KERNEL="uek"
 
 # Update: yes, security, no
 UPDATE_TO_LATEST="yes"
+
+# Directory used to save build information
+readonly BUILD_INFO="/.build-info"

--- a/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
@@ -68,7 +68,7 @@ logvol /      --fstype=\"xfs\"  --vgname=vg_main --size=4096 --name=lv_root --gr
 #######################################
 # Cleanup actions run directly on the image
 # Globals:
-#   WORKSPACE VM_NAME
+#   WORKSPACE VM_NAME BUILD_INFO
 # Arguments:
 #   root filesystem directory
 #   boot filesystem directory
@@ -83,10 +83,9 @@ distr::image_cleanup() {
   [[ -z ${root_fs} ]] && error "Undefined root filesystem"
   [[ -z ${boot_fs} ]] && error "Undefined boot filesystem"
 
-  cp "${root_fs}"/home/rpm.list "${WORKSPACE}/${VM_NAME}/${VM_NAME}.pkglst"
-  cp "${root_fs}"/home/rpm.csv "${WORKSPACE}/${VM_NAME}/pkglst.csv"
-  cp "${root_fs}"/home/repolist.txt "${WORKSPACE}/${VM_NAME}/repolist.txt"
-  cp "${root_fs}"/home/kernel.txt "${WORKSPACE}/${VM_NAME}/${VM_NAME}.kernel"
+  if [[ -n ${BUILD_INFO} && -d "${root_fs}${BUILD_INFO}" ]]; then
+    find "${root_fs}${BUILD_INFO}" -type f -exec cp {} "${WORKSPACE}/${VM_NAME}/" \;
+  fi
 
   sudo chroot "${root_fs}" /bin/bash <<-EOF
   : > /var/log/wtmp
@@ -97,6 +96,6 @@ distr::image_cleanup() {
 	rm -rf /var/spool/root /var/spool/mail/root
 	rm -rf /var/lib/NetworkManager
 	rm -rf /var/tmp/*
-	rm -f /home/rpm.list /home/rpm.csv /home/repolist.txt /home/kernel.txt
+  [[ -n "${BUILD_INFO}" ]] && rm -rf "${BUILD_INFO}"
 	EOF
 }

--- a/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
@@ -44,8 +44,9 @@ distr::kickstart() {
 
   local btrfs="\
 part btrfs.01 --fstype=\"btrfs\"  --ondisk=sda --size=4096 --grow\n\
-btrfs none --label=btr_pool --data=single btrfs.01\n\
-btrfs /    --subvol --name=root btr_pool\
+btrfs none  --label=btrfs_vol --data=single btrfs.01\n\
+btrfs /     --subvol --name=root LABEL=btrfs_vol\n\
+btrfs /home --subvol --name=home LABEL=btrfs_vol\
 "
   local lvm="\
 part pv.01 --ondisk=sda --size=4096 --grow\n\

--- a/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
@@ -28,6 +28,10 @@ timezone UTC --isUtc
 # Network information
 network  --bootproto=dhcp --device=eth0 --onboot=yes --ipv6=auto --hostname=localhost.localdomain
 
+# URL to an installation tree on a remote server
+
+# Additional yum repositories that may be used as sources for package installation.
+
 # Root password -- will be overridden by the builder
 rootpw --lock
 

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -113,7 +113,7 @@ distr::kernel_config() {
 #######################################
 # Common configuration
 # Globals:
-#   UPDATE_TO_LATEST
+#   UPDATE_TO_LATEST, BUILD_INFO
 # Arguments:
 #   None
 # Returns:
@@ -121,6 +121,9 @@ distr::kernel_config() {
 #######################################
 distr::common_cfg() {
   local service tty
+
+  # Directory to save build information
+  mkdir -p "${BUILD_INFO}"
 
   # Run dnf update if flag is set to yes in image build page
   echo_message "Update image: ${UPDATE_TO_LATEST^^}"
@@ -213,6 +216,7 @@ distr::provision() {
 #######################################
 # Cleanup
 # Globals:
+#   BUILD_INFO
 # Arguments:
 #   None
 # Returns:
@@ -247,7 +251,7 @@ distr::cleanup() {
   done
 
   echo_message "Dnf cleanup"
-  dnf -q repolist > /home/repolist.txt
+  dnf -q repolist > "${BUILD_INFO}/repolist.txt"
   : > /etc/dnf/vars/ociregion
   rm -rf /var/cache/dnf/*
   rm -rf /var/lib/dnf/*
@@ -331,9 +335,9 @@ distr::cleanup() {
   rm -f /var/log/ovm-template-config.log
 
   echo_message "Save list of installed packages"
-  rpm -qa --qf "%{name}.%{arch}\n"  | sort -u > /home/rpm.list
-  rpm -qa --qf '"%{NAME}","%{EPOCHNUM}","%{VERSION}","%{RELEASE}","%{ARCH}"\n' | sort > /home/rpm.csv
-  uname -r > /home/kernel.txt
+  rpm -qa --qf "%{name}.%{arch}\n"  | sort -u > "${BUILD_INFO}/pkglist.txt"
+  rpm -qa --qf '"%{NAME}","%{EPOCHNUM}","%{VERSION}","%{RELEASE}","%{ARCH}"\n' | sort > "${BUILD_INFO}/pkglist.csv"
+  uname -r > "${BUILD_INFO}/kernel.txt"
 
   echo_message "Relabel SELinux"
   genhomedircon

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -79,6 +79,14 @@ CLOUD="none"
 # If defined, override generated VM_NAME
 # VM_NAME=
 
+# If your ISO_URL points to a boot iso, you need to provide:
+#   - an URL to an installation tree on a remote server
+#   - optionally an associative array of additional yum repositories that may
+#     be used as sources for package installation.
+# Example for an OL8 install:
+# REPO_URL="http://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64"
+# REPO[AppStream]="https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64"
+
 # OVM Image version (Default: 1.0)
 # IMAGE_VERSION=
 

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -11,7 +11,7 @@
 # Workspace for the builder and location of the artifacts
 WORKSPACE=
 # ISO_URL -- location of the ISO file
-# Can be local (file://) or remote (http://) but it must be an URL
+# Can be local (file://) or remote (https://) but it must be an URL
 ISO_URL=
 # ISO_SHA1 -- checksum for the ISO file
 ISO_SHA1_CHECKSUM=
@@ -84,7 +84,7 @@ CLOUD="none"
 #   - optionally an associative array of additional yum repositories that may
 #     be used as sources for package installation.
 # Example for an OL8 install:
-# REPO_URL="http://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64"
+# REPO_URL="https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64"
 # REPO[AppStream]="https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64"
 
 # OVM Image version (Default: 1.0)

--- a/oracle-linux-image-tools/env.properties.defaults
+++ b/oracle-linux-image-tools/env.properties.defaults
@@ -42,3 +42,10 @@ PACKER_BUILD_OPTIONS="-on-error=ask"
 
 # If defined, override generated VM_NAME
 VM_NAME=
+
+# The following two parameters can be specified when using a boot install image 
+# instead of a full DVD ISO image
+# URL to an installation tree on a remote server
+REPO_URL=
+# Associative array of repos to be added in the kickstart file
+declare -gA REPO


### PR DESCRIPTION
This PR allows provisioning from a boot ISO image.

It also enables btrfs root filesystem which will be supported as from Oracle Linux 8 Update 3.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>