### PR TITLE
oci-compute update

### DIFF
--- a/oci-compute/oci_compute/oci_compute.py
+++ b/oci-compute/oci_compute/oci_compute.py
@@ -111,7 +111,9 @@ class OciCompute(object):
         self._echo_message_kv('Name', vcn.display_name)
 
         self._echo_header('Retrieving subnet')
-        subnets = self._virtual_network_client.list_subnets(compartment_id, vcn.id, display_name=subnet_name).data
+        subnets = self._virtual_network_client.list_subnets(compartment_id,
+                                                            vcn_id=vcn.id,
+                                                            display_name=subnet_name).data
 
         if not subnets:
             self._echo_error('No matching subnet for "{}"'.format(subnet_name))

--- a/oci-compute/oci_compute/oci_compute.py
+++ b/oci-compute/oci_compute/oci_compute.py
@@ -15,6 +15,10 @@ from click import confirm, echo, secho
 import oci
 
 
+# OS name for Custom images
+CUSTOM_OS = ('Custom', 'Zero')
+
+
 class OciCompute(object):
     """Interface with the OCI SDK."""
 
@@ -301,7 +305,7 @@ class OciCompute(object):
         response = oci.pagination.list_call_get_all_results(self._compute_client.list_images, compartment_id)
         images = set()
         for image in response.data:
-            if image.operating_system != 'Custom':
+            if image.operating_system not in CUSTOM_OS:
                 images.add((image.operating_system, image.operating_system_version))
 
         return sorted(images)
@@ -316,7 +320,7 @@ class OciCompute(object):
         response = oci.pagination.list_call_get_all_results(self._compute_client.list_images, compartment_id)
         images = set()
         for image in response.data:
-            if image.operating_system == 'Custom':
+            if image.operating_system in CUSTOM_OS:
                 images.add((image.display_name, image.time_created))
 
         return sorted(images)
@@ -414,14 +418,13 @@ class OciCompute(object):
         self._echo_header('Retrieving image details')
         response = self._compute_client.list_images(
             compartment_id,
-            operating_system='Custom',
             shape=shape,
             sort_by='DISPLAYNAME',
             sort_order='ASC')
         # Find matching names
         images = []
         for image in response.data:
-            if custom_image_name in image.display_name:
+            if image.operating_system in CUSTOM_OS and custom_image_name in image.display_name:
                 images.append(image)
         if not images:
             self._echo_error("No image found")

--- a/oci-compute/oci_compute/oci_compute.py
+++ b/oci-compute/oci_compute/oci_compute.py
@@ -463,7 +463,7 @@ class OciCompute(object):
             return None
         elif len(listings) > 1:
             self._echo_error("More than one image found:")
-            for name in sorted(l.name for l in listings):
+            for name in sorted(listing.name for listing in listings):
                 self._echo_error('    {}'.format(name))
             return None
         listing = listings[0]

--- a/oci-compute/setup.py
+++ b/oci-compute/setup.py
@@ -38,7 +38,7 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'click>=7.0',
-        'oci>=2.10',
+        'oci>=2.23',
         'terminaltables>=3.1',
     ],
     entry_points={


### PR DESCRIPTION
This PR addresses 2 issues:
- Breaking changed introduced in [OCI SDK 2.18.0](https://github.com/oracle/oci-python-sdk/blob/master/CHANGELOG.rst#2180---2020-07-14) making parameter vcn_id optional
- Consider images having "Zero" operating system as Custom images
