### PR TITLE
OL8U3 and Packer 1.6 support

### DIFF
--- a/oracle-linux-image-tools/README.md
+++ b/oracle-linux-image-tools/README.md
@@ -55,9 +55,9 @@ The tool currently supports:
   Minimal configuration:
     - `WORKSPACE`: path of your workspace directory
     - `ISO_URL`: location of the Oracle Linux distribution ISO
-    - `ISO_SHA1_CHECKSUM`: SAH1 checksum for the ISO file
+    - `ISO_CHECKSUM`: checksum for the ISO file. As from packer 1.6.0, you can prepend the checksum type (see [packer documentation](https://www.packer.io/docs/builders/virtualbox/iso#iso_checksum))
     - `CLOUD`: cloud target (azure, oci, olvm, ovm or none)
-1. Run the buider:  
+1. Run the builder:  
   `./bin/build-image.sh --env ENV_PROPERTY_FILE`
 
 ## Advanced configuration

--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -176,8 +176,8 @@ load_env() {
 
   # Basic validation
   [[ -z "${ISO_URL}" ]] && error "missing ISO URL"
-  [[ -z "${ISO_SHA1_CHECKSUM}" ]] && error "missing ISO checksum"
-  readonly ISO_URL ISO_SHA1_CHECKSUM
+  [[ -z "${ISO_CHECKSUM}" ]] && error "missing ISO checksum"
+  readonly ISO_URL ISO_CHECKSUM
 
   [[ -z "${SSH_PASSWORD}" && -z "${SSH_KEY_FILE}" ]] &&
     error "need at least ssh key or password"
@@ -360,7 +360,7 @@ stage_kickstart() {
 # Generate Packer config file
 # Globals:
 #   DISK_SIZE_MB MEM_SIZE CPU_NUM
-#   ISO_URL ISO_SHA1_CHECKSUM
+#   ISO_URL ISO_CHECKSUM
 #   KS_FILE
 #   SERIAL_CONSOLE
 #   SHUTDOWN_CMD
@@ -400,8 +400,7 @@ packer_conf() {
 	      "type": "virtualbox-iso",
 	      "guest_os_type": "Oracle_64",
 	      "iso_url": "${ISO_URL}",
-	      "iso_checksum_type": "sha1",
-	      "iso_checksum": "${ISO_SHA1_CHECKSUM}",
+	      "iso_checksum": "${ISO_CHECKSUM}",
 	      "output_directory": "${WORKSPACE}/${VM_NAME}",
 	      "vm_name": "${VM_NAME}",
 	      "hard_drive_interface": "sata",

--- a/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
@@ -136,6 +136,11 @@ EOF
 # make sure firstboot doesn't start
 echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
 
+echo "Kernel configuration"
+# Remove the big rescue image if present
+dnf remove -y dracut-config-rescue
+rm -f /boot/{initramfs,vmlinuz}-0-rescue-$(cat /etc/machine-id)*
+
 # Ensure we don't reboot with the serial console enabled
 sed -i \
   -e 's/ console=ttyS0//' \

--- a/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
@@ -74,7 +74,6 @@ part /        --fstype="xfs"  --ondisk=sda --size=4096 --label=root  --grow
 -NetworkManager-team
 -NetworkManager-tui
 -biosdevname
--dracut-config-rescue
 -iwl100-firmware
 -iwl1000-firmware
 -iwl105-firmware

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -13,8 +13,8 @@ WORKSPACE=
 # ISO_URL -- location of the ISO file
 # Can be local (file://) or remote (https://) but it must be an URL
 ISO_URL=
-# ISO_SHA1 -- checksum for the ISO file
-ISO_SHA1_CHECKSUM=
+# ISO_CHECKSUM -- checksum for the ISO file
+ISO_CHECKSUM=
 
 #
 # Optional parameters


### PR DESCRIPTION
This PR covers 2 topics:

- Support for OL8 Update 3: the kickstart process now requires the `dracut-config-rescue` package. We remove the rescue kernel afterwards to reduce the image size as it represents about 20% of the final image size!
- Support for latest Packer version. Packer 1.6 deprecates the `iso_checksum_type` parameter. Type can now be prepended to the checksum string. If the type is not specified Packer will try to infer it based on string length and this works on older versions as well, so the builder is compatible with Packer version 1.4 and above.