### PR TITLE
OL8 fixes

### DIFF
--- a/oracle-linux-image-tools/cloud/azure/provision.sh
+++ b/oracle-linux-image-tools/cloud/azure/provision.sh
@@ -33,6 +33,9 @@ cloud::install_WALinuxAgent()
   elif [[ "${ORACLE_RELEASE}" = "8" ]]; then
     dnf install -y parted hypervkvpd
     dnf install -y WALinuxAgent dnsmasq
+    if [[ -z "${RESCUE_KERNEL}" || "${RESCUE_KERNEL,,}" = "no" ]]; then
+      dnf remove -y dracut-config-rescue
+    fi
   else
     echo "Unsupported OL version"
     exit

--- a/oracle-linux-image-tools/cloud/ovm/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/cloud/ovm/ol8-slim/env.properties
@@ -1,0 +1,6 @@
+# Default parameter for the OVM cloud on OL8.
+# Do NOT change anything in this file, customisation must be done in separate
+# env file.
+
+# Add additional kernel (Image will have both UEK and RHCK installed)
+EXTRA_KERNEL="no"

--- a/oracle-linux-image-tools/cloud/ovm/ol8-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/cloud/ovm/ol8-slim/image-scripts.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Validate parameters
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl
+#
+# Description: this module provides:
+#   cloud_distr::validate: parameter validation
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+#######################################
+# Parameter validation
+# Globals:
+#   EXTRA_KERNEL
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+cloud_distr::validate() {
+  [[ "${EXTRA_KERNEL,,}" =~ ^(yes)|(no)$ ]] || error "EXTRA_KERNEL must be yes or no"
+  readonly EXTRA_KERNEL
+}

--- a/oracle-linux-image-tools/cloud/ovm/provision.sh
+++ b/oracle-linux-image-tools/cloud/ovm/provision.sh
@@ -64,10 +64,8 @@ cloud::ovm_cfg()
 
   echo_message 'Configure grub'
   cloud::default_grub GRUB_TIMEOUT 10
-  # GRUB_HIDDEN_MENU_QUIET: for historical reason, AFAIK there is no shuch
-  # parameter...
+  # GRUB_HIDDEN_MENU_QUIET: for historical reason, not used anymore...
   cloud::default_grub GRUB_HIDDEN_MENU_QUIET false
-  cloud::default_grub GRUB_TIMEOUT_STYLE countdown
   cloud::default_grub GRUB_SERIAL_COMMAND '"serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"'
   sed -i -e '/^GRUB_TERMINAL/d' /etc/default/grub
   cloud::default_grub GRUB_TERMINAL '"serial console"'

--- a/oracle-linux-image-tools/cloud/ovm/provision.sh
+++ b/oracle-linux-image-tools/cloud/ovm/provision.sh
@@ -14,6 +14,30 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 
+cloud::default_grub()
+#######################################
+# Set values in /etc/default/grub
+# Globals:
+#   None
+# Arguments:
+#   Key: key to set
+#   Value: value
+# Returns:
+#   None
+#######################################
+{
+  key="$1"
+  value="$2"
+
+  if grep -q "^${key}=" /etc/default/grub; then
+    # Replace parameter
+    sed -i -e "s/^${key}=.*/${key}=${value}/" /etc/default/grub
+  else
+    # Add parameter
+    echo "${key}=${value}" >> /etc/default/grub
+  fi
+}
+
 #######################################
 # Configure OVM instance
 # Globals:
@@ -39,16 +63,14 @@ cloud::ovm_cfg()
 	EOF
 
   echo_message 'Configure grub'
-  cat > /etc/default/grub  <<-EOF
-	GRUB_TIMEOUT=10
-	GRUB_HIDDEN_MENU_QUIET=false
-	GRUB_DEFAULT=saved
-	GRUB_DISABLE_SUBMENU=true
-	GRUB_TERMINAL="serial console"
-	GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
-	GRUB_CMDLINE_LINUX="console=tty0"
-	GRUB_DISABLE_RECOVERY="true"
-	EOF
+  cloud::default_grub GRUB_TIMEOUT 10
+  # GRUB_HIDDEN_MENU_QUIET: for historical reason, AFAIK there is no shuch
+  # parameter...
+  cloud::default_grub GRUB_HIDDEN_MENU_QUIET false
+  cloud::default_grub GRUB_TIMEOUT_STYLE countdown
+  cloud::default_grub GRUB_SERIAL_COMMAND '"serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"'
+  sed -i -e '/^GRUB_TERMINAL/d' /etc/default/grub
+  cloud::default_grub GRUB_TERMINAL '"serial console"'
 
   #Regenerate grub.cfg
   grub2-mkconfig -o /boot/grub2/grub.cfg

--- a/oracle-linux-image-tools/cloud/vagrant-virtualbox/files/vagrant-common.sh
+++ b/oracle-linux-image-tools/cloud/vagrant-virtualbox/files/vagrant-common.sh
@@ -144,7 +144,7 @@ For additional packages, updates, documentation and community help, see:
 #######################################
 # Cleanup module
 # Globals:
-#   None
+#   ORACLE_RELEASE RESCUE_KERNEL
 # Arguments:
 #   None
 # Returns:
@@ -160,7 +160,9 @@ vagrant::cleanup()
       psmisc \
       m2crypto \
       checkpolicy \
-      dracut-config-rescue \
       iptables-services
+    if [[ -z "${RESCUE_KERNEL}" || "${RESCUE_KERNEL,,}" = "no" ]]; then
+      distr::remove_rpms dracut-config-rescue
+    fi
   fi
 }

--- a/oracle-linux-image-tools/distr/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-slim/env.properties
@@ -21,6 +21,14 @@ BOOT_COMMAND='<up><tab>${CONSOLE} text ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} 
 # Kernel: uek, rhck
 KERNEL="uek"
 
+# Keep rescue kernel: yes, no
+# Keeping rescue kernel will increase the image size and is most propbalbly
+# not very useful in cloud environment.
+# Note that if you enable rescue kernel and due the way BLS config works, you
+# will have a second rescue kernel the first time kernel is upgrade as the
+# machine-id differs between image build and deployed VM.
+RESCUE_KERNEL="no"
+
 # Update: yes, security, no
 UPDATE_TO_LATEST="yes"
 

--- a/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
@@ -18,7 +18,7 @@
 #######################################
 # Validate distribution parameters
 # Globals:
-#   ROOT_FS
+#   RESCUE_LERNEL ROOT_FS
 # Arguments:
 #   None
 # Returns:
@@ -26,14 +26,15 @@
 #######################################
 distr::validate() {
   [[ "${ROOT_FS,,}" =~ ^(xfs)|(btrfs)|(lvm)$ ]] || error "ROOT_FS must be xfs, btrfs or lvm"
-  [[ "${ROOT_FS,,}" = "btrfs" ]] && echo_message "Note that for btrfs root filesystem you need to use an UEK boot ISO"  
-  readonly ROOT_FS
+  [[ "${ROOT_FS,,}" = "btrfs" ]] && echo_message "Note that for btrfs root filesystem you need to use an UEK boot ISO"
+  [[ "${RESCUE_KERNEL,,}" =~ ^(yes)|(no)$ ]] || error "RESCUE_KERNEL must be yes or no"
+  readonly RESCUE_KERNEL ROOT_FS
 }
 
 #######################################
 # Kickcstart fixup
 # Globals:
-#   ROOT_FS
+#   RESCUE_KERNEL ROOT_FS
 # Arguments:
 #   kickstart file name
 # Returns:
@@ -62,8 +63,9 @@ logvol /      --fstype=\"xfs\"  --vgname=vg_main --size=4096 --name=lv_root --gr
     sed -i -e '/^part swap/d' -e 's!^part / .*$!'"${lvm}"'!' "${ks_file}"
   fi
 
-  # Pass kernel selection
+  # Pass kernel and rescue kernel selections
   sed -i -e 's!^KERNEL=.*$!KERNEL='"${KERNEL}"'!' "${ks_file}"
+  sed -i -e 's!^RESCUE_KERNEL=.*$!RESCUE_KERNEL='"${RESCUE_KERNEL}"'!' "${ks_file}"
 }
 
 #######################################

--- a/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
@@ -138,8 +138,12 @@ echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
 
 echo "Kernel configuration"
 # Remove the big rescue image if present
-dnf remove -y dracut-config-rescue
-rm -f /boot/{initramfs,vmlinuz}-0-rescue-$(cat /etc/machine-id)*
+RESCUE_KERNEL=no
+if [[ "${RESCUE_KERNEL,,}" = "no" ]]; then
+  dnf remove -y dracut-config-rescue
+  rm -f /boot/{initramfs,vmlinuz}-0-rescue-$(cat /etc/machine-id)*
+  rm -f /boot/loader/entries/$(cat /etc/machine-id)-0-rescue.conf
+fi
 
 # Ensure we don't reboot with the serial console enabled
 sed -i \


### PR DESCRIPTION
- Support for OL8 OVM images
- Add `RESCUE_KERNEL` parameter for OL8 images to add a rescue kernel in the image
- Fixes issue where GRUB_ENABLE_BLSCFG parameter was dropped in OL8.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>